### PR TITLE
helping users find other methods (etc.)

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,6 +17,6 @@ title: Method Cards
 - [**Make**](./make/): Move toward a final product that’s ready to be released and tested.
 - [**Validate**](./validate/): Test your research, design, and product.
 
-## We’ve called out specifics about doing this work in government.
+## We’ve called out specifics about doing this work in government
 
 For the most part, the processes are the same as anywhere. However, to stay on the happy side of the law, take a look at methods for [Recruiting](../recruiting/), [Incentives](../incentives/), [Informed consent](../informed-consent/), [Privacy](../privacy/), and the [Paperwork Reduction Act](../paperwork-reduction-act/). No matter which other methods we work with, these are the [foundations](../foundations/) for all our design research.

--- a/pages/affinity-diagramming.md
+++ b/pages/affinity-diagramming.md
@@ -18,7 +18,7 @@ Quick and collaborative approach for drawing insights from qualitative data.
 
 ## How to do it
 
-1. Record ideas, quotes, or observations from [interviews](../stakeholder-and-user-interviews/), [contextual inquiry](../contextual-inquiry/), or other sources of research on Post-It notes notes.
+1. Record ideas, quotes, or observations from [interviews](../stakeholder-and-user-interviews/), [contextual inquiry](../contextual-inquiry/), or other sources of research on Post-It notes.
 
 2. Place the Post-It notes on a white board (in no particular arrangement). Move the Post-It notes into related groups.
 

--- a/pages/affinity-diagramming.md
+++ b/pages/affinity-diagramming.md
@@ -18,7 +18,7 @@ Quick and collaborative approach for drawing insights from qualitative data.
 
 ## How to do it
 
-1. Record ideas, quotes, or observations from interviews, contextual inquiry, or other sources of research on Post-It notes notes.
+1. Record ideas, quotes, or observations from [interviews](../stakeholder-and-user-interviews/), [contextual inquiry](../contextual-inquiry/), or other sources of research on Post-It notes notes.
 
 2. Place the Post-It notes on a white board (in no particular arrangement). Move the Post-It notes into related groups.
 

--- a/pages/bodystorming.md
+++ b/pages/bodystorming.md
@@ -22,7 +22,7 @@ To remind participants that interactions are human and physical, to teach stakeh
 
 2. Bring the project team to the user’s environment. If that’s not practical, model the user’s environment in a conference room.
 
-3. Assign each member of the project team to a role, interface, or “touchpoint” that you have identified in a journey map. If users are present, ask them to pretend to accomplish their goals in their usual way. If users are absent, assign a persona to each member of the product team that isn’t serving as a touchpoint. If you anticipate discomfort, assign roles in advance and start with a basic script.
+3. Assign each member of the project team to a role, interface, or “touchpoint” that you have identified in a journey map. If users are present, ask them to pretend to accomplish their goals in their usual way. If users are absent, assign a [persona](../personas/) to each member of the product team that isn’t serving as a touchpoint. If you anticipate discomfort, assign roles in advance and start with a basic script.
 
 4. Use props to role play how users accomplish their goals. “Speak the interface” to one another. For example, one of the touchpoints might say “Submit all of your required forms,” and the user might respond “Arg! I don’t know what forms are required!”
 
@@ -31,7 +31,6 @@ To remind participants that interactions are human and physical, to teach stakeh
 ## Applied in government research:
 
 - No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation like those that bodystorming entails, 5 CFR 1320.5(h)3.
-
 - If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 ## Additional resources

--- a/pages/card-sorting.md
+++ b/pages/card-sorting.md
@@ -40,4 +40,4 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation 5 CFR 1320.5(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.5(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.5(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -32,7 +32,7 @@ To understand whether a design solution is easy for a new or infrequent user to 
 
 ## Applied in government research
 
--  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that [bodystorming](../bodystorming/) entails, 5 CFR 1320.5(h)3.
+-  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.5(h)3.
 -  If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 Additional resources:

--- a/pages/comparative-analysis.md
+++ b/pages/comparative-analysis.md
@@ -10,7 +10,7 @@ A detailed review of existing experiences provided either by direct competitors 
 
 ## Reasons to use it
 
-To identify competitors’ solutions that excel, are lacking, or are missing critical design elements. Comparative analysis can  give new solutions a competitive edge by identifying areas of opportunity, gaps in experience offerings, and potential design patterns to adopt or avoid.
+To identify competitors’ solutions that excel, are lacking, or are missing critical design elements. Comparative analysis can give new solutions a competitive edge by identifying areas of opportunity, gaps in experience offerings, and potential design patterns to adopt or avoid.
 
 ## Time required
 

--- a/pages/contextual-inquiry.md
+++ b/pages/contextual-inquiry.md
@@ -10,7 +10,7 @@ The product team unobtrusively observes participants at work, with their permiss
 
 ## Reasons to use it
 
-To learn how and why users do what they do; to discover needs and attitudes that might not emerge in an interview; to map how tools, digital and otherwise, interact during complex activities.
+To learn how and why users do what they do; to discover needs and attitudes that might not emerge in an [interview](../stakeholder-and-user-interviews/); to map how tools, digital and otherwise, interact during complex activities.
 
 ## Time required
 
@@ -20,7 +20,7 @@ To learn how and why users do what they do; to discover needs and attitudes that
 
 1. With permission from a supervisor and from the participant, schedule a time to watch a typical work activity and record data.
 
-2. While observing, ask the participant to act normally. Pretend you're a student learning how to do the job. Ask questions to help you understand what the person is doing and why.
+2. While observing, ask the participant to act normally. Pretend you’re a student learning how to do the job. Ask questions to help you understand what the person is doing and why.
 
 3. At the end of the session, explain what you have learned and check for errors.
 

--- a/pages/design-studio.md
+++ b/pages/design-studio.md
@@ -18,7 +18,7 @@ To create a shared understanding and appreciation of design problems confronting
 
 ## How to do it
 
-1. Invite between six and 12 participants: stakeholders, users, and project team members who need to build a shared understanding. Provide invitees ahead of time with the design prompt for the session. Share applicable research already conducted. Unless users will be present, share personas summarizing what users are trying to do and why.
+1. Invite between six and 12 participants: stakeholders, users, and project team members who need to build a shared understanding. Provide invitees ahead of time with the design prompt for the session. Share applicable research already conducted. Unless users will be present, share [personas](../personas/) summarizing what users are trying to do and why.
 
 2. Bring drawing materials to the meeting. At the start of the meeting, review the design prompt and research you shared.
 

--- a/pages/journey-mapping.md
+++ b/pages/journey-mapping.md
@@ -26,11 +26,11 @@ To provide design teams with a bird’s-eye view of a design system, helping the
  - The emotions associated with these moments or decisions. Emoticons or emoji work well here.
 
 2. Create a visual map showing the order in which people exhibit behaviors, use information, make decisions, and have emotions. A few different approaches:
- - Group elements into a table of “phases” related to the personal narrative of each persona.
+ - Group elements into a table of “phases” related to the personal narrative of each [persona](../personas/).
  - Create a graphic representation of this data by illustrating the narrative of each persona and where they share contextual components with one another.
  - A combination of the two.
 
-3. Discuss the map with stakeholders. Point out insights it offers. Use these insights to establish design principles. Think about how to collapse or accelerate a customer’s journey through the various phases. Incorporate this information into the project’s scope.
+3. Discuss the map with stakeholders. Point out insights it offers. Use these insights to establish [design principles](../design-principles/). Think about how to collapse or accelerate a customer’s journey through the various phases. Incorporate this information into the project’s scope.
 
 You can also map user journeys as part of a workshop with stakeholders, similar to a [design studio](../design-studio/).
 

--- a/pages/prototyping.md
+++ b/pages/prototyping.md
@@ -10,7 +10,7 @@ A rudimentary version, either static or functional, of something that exhibits b
 
 ## Reasons to use it
 
-To enable direct examination of a design concept’s viability with a number of other methods such as usability testing or a cognitive walkthrough. Static prototypes (often paper) are helpful for gaining feedback on users’ intentions and various design elements. Functional prototypes (often coded) are helpful for observing how users interact with the product.
+To enable direct examination of a design concept’s viability with a number of other methods such as [usability testing](../usability-testing/) or a [cognitive walkthrough](../cognitive-walkthrough/). Static prototypes (often paper) are helpful for gaining feedback on users’ intentions and various design elements. Functional prototypes (often coded) are helpful for observing how users interact with the product.
 
 ## Time required
 

--- a/pages/stakeholder-and-user-interviews.md
+++ b/pages/stakeholder-and-user-interviews.md
@@ -21,7 +21,7 @@ To build consensus about the problem statement and research objectives.
 1. Come to the interview with a guide for yourself of some areas you’d like to ask about, and some specific questions as a back up. Questions will often concern the individual’s role, the organization, the individuals’ needs, and metrics for success of the project. Possible starters:
  - &ldquo;What did you do yesterday?&rdquo;
  - Ask lots of &ldquo;why is that&rdquo; and &ldquo;how do you do that&rdquo; questions.
- - If there are other products they use or your product doesn’t have constraints imposed by prior work, observe the stakeholders using a competing product.
+ - If there are other products they use or your product doesn’t have constraints imposed by prior work, observe the stakeholders using a [competing product](../comparative-analysis/).
 
 2. Sit down one-on-one with the participant, or two-on-one with a note-taker or joint interviewer, in a focused environment. Introduce yourself. Explain the premise for the interview as far as you can without biasing their responses.
 

--- a/pages/usability-testing.md
+++ b/pages/usability-testing.md
@@ -18,11 +18,11 @@ To learn a given design’s challenges, opportunities, and successes.
 
 ## How to do it
 
-1. [Create a prototype](../prototyping/) that sufficiently conveys the team’s hypothesis based on research. In the absence of a prototype, consider testing a competitor’s product.
+1. [Create a prototype](../prototyping/) that sufficiently conveys the team’s hypothesis based on research. In the absence of a prototype, consider testing a [competitor’s product](../comparative-analysis/).
 
-2. Stage a scenario in which someone who would actually use your product tries to employ the prototype for their own ends. Record their attempt. Optionally: 
+2. Stage a scenario in which someone who would actually use your product tries to employ the prototype for their own ends. Record their attempt. Optionally:
  - Ask users to think out loud as they try.
- - Compensate the participant for their time.
+ - [Compensate the participant](../incentives/) for their time.
 
 3. Avoid asking participants to perform tasks far outside their normal context. This will lead them to reflect on the design rather than their ability to accomplish their goals. (For example, to test a new layout for a “user account” section on a voter registration website, recruit only people who already register to vote online.)
 


### PR DESCRIPTION
## Changes
mostly this was adding links to other method pages where appropriate. a
couple other minor things:
- consistent punctuation in index page headers
- changed an incorrect reference in the gov research section of
cognitive-walkthrough
- inserted a missing comma
- removed an extra in-line space
- changed a straight apostrophe to curled

## Review
@jenniferthibault 

## Notes
In two places I linked references to a competing product to the comparative analysis file. In context, the references are to understanding opportunities and patterns based on observing user behavior. Comparative analysis gives you a way of identifying which behaviors you’d be testing for. But I’m not sure if people will be confused by going to something with different words in the title. /shrug