### PR TITLE
Fixing parent page links

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,4 +19,4 @@ title: Method Cards
 
 ## We’ve called out specifics about doing this work in government
 
-For the most part, the processes are the same as anywhere. However, to stay on the happy side of the law, take a look at methods for [Recruiting](../recruiting/), [Incentives](../incentives/), [Informed consent](../informed-consent/), [Privacy](../privacy/), and the [Paperwork Reduction Act](../paperwork-reduction-act/). No matter which other methods we work with, these are the [foundations](../foundations/) for all our design research.
+For the most part, the processes are the same as anywhere. However, to stay on the happy side of the law, take a look at methods for [Recruiting](./recruiting/), [Incentives](./incentives/), [Informed consent](./informed-consent/), [Privacy](./privacy/), and the [Paperwork Reduction Act](./paperwork-reduction-act/). No matter which other methods we work with, these are the [foundations](./foundations/) for all our design research.

--- a/pages/decide.md
+++ b/pages/decide.md
@@ -8,7 +8,7 @@ Use what you’ve learned to start focusing your research on specific areas and 
 
 ### Analysis
 
-- [Comparitive analysis](../comparitive-analysis/)
+- [Comparative analysis](../comparative-analysis/)
 - [Content audit](../content-audit/)
 - [Design principles](../design-principles/)
 - [Task flow analysis](../task-flow-analysis/)


### PR DESCRIPTION
- spelling for comparitive/comparative
- fixed directory reference (I think) for foundations