### PR TITLE
Copy edits found while putting content into the print template

### DIFF
--- a/pages/card-sorting.md
+++ b/pages/card-sorting.md
@@ -20,7 +20,7 @@ To create content structures that are user-informed and intuitive.
 
 There are two types of card sorting: open and closed. Most card sorts are performed with one user at a time, but you can also do the exercise with groups of two to three people.
 
-## Open card sort
+### Open card sort
 
 1. Give users a collection of content represented on cards.
 
@@ -30,7 +30,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 4. Ask users to tell you why they grouped the cards and labeled the categories as they did.
 
-## Closed card sort
+### Closed card sort
 
 1. Give users a collection of content represented on cards.
 

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -35,6 +35,6 @@ To understand whether a design solution is easy for a new or infrequent user to 
 -  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.5(h)3.
 -  If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
-Additional resources:
+## Additional resources
 - [`http://www.usabilitybok.org/cognitive-walkthrough`](http://www.usabilitybok.org/cognitive-walkthrough)
 - [`http://www.usabilityfirst.com/usability-methods/cognitive-walkthroughs/`](http://www.usabilitybok.org/cognitive-walkthrough)

--- a/pages/design-studio.md
+++ b/pages/design-studio.md
@@ -14,7 +14,7 @@ To create a shared understanding and appreciation of design problems confronting
 
 ## Time required
 
-**Small:** 3-4 hours
+**Small:** 3–4 hours
 
 ## How to do it
 
@@ -22,7 +22,7 @@ To create a shared understanding and appreciation of design problems confronting
 
 2. Bring drawing materials to the meeting. At the start of the meeting, review the design prompt and research you shared.
 
-3. Distribute drawing materials. Ask participants to individually sketch concepts that address the prompt. Remind them that anyone can draw and artistic accuracy is not the goal of the exercise. 15-20 minutes.
+3. Distribute drawing materials. Ask participants to individually sketch concepts that address the prompt. Remind them that anyone can draw and artistic accuracy is not the goal of the exercise. 15–20 minutes.
 
 4. Have participants present their ideas to one another in groups of three and solicit critiques.
 
@@ -34,7 +34,7 @@ To create a shared understanding and appreciation of design problems confronting
 
 ## Applied in government research
 
-No PRA Implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
+No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
 
 ## Additional resources
 

--- a/pages/heuristic-analysis.md
+++ b/pages/heuristic-analysis.md
@@ -10,7 +10,7 @@ A quick way to find common, large usability problems on a website.
 
 ## Reasons to use it:
 
-Quickly identify common design problems that make websites hard to use with conducting more involved user research.
+To quickly identify common design problems that make websites hard to use with conducting more involved user research.
 
 ## Time required
 

--- a/pages/mental-modeling.md
+++ b/pages/mental-modeling.md
@@ -28,7 +28,7 @@ To help designers anticipate how design decisions might facilitate future behavi
 
 ## Applied in government research
 
-No PRA Implications. No information is collected from members of the public.
+No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 

--- a/pages/metrics-definition.md
+++ b/pages/metrics-definition.md
@@ -30,7 +30,7 @@ To keep the team vigilant about the user’s perspective and to establish a user
 
 ## Applied in government research
 
-No PRA Implications. No information is collected from members of the public.
+No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 

--- a/pages/recruiting.md
+++ b/pages/recruiting.md
@@ -33,7 +33,8 @@ Time spent with the right people using the wrong methods is better than time spe
 
 ## Applied in government research
 
-When you recruit users who are not government employees, complying with the Anti-Deficiency Act requires you to either:
+When you recruit users who are not government employees, complying with the Anti-Deficiency Act requires you to either:  
+
 - Give all members of the public an opportunity to participate (by posting the opportunity to participate somewhere everyone can see it, like your website or Github), or
 - Get participants to agree, in writing, to the statement: “I understand that I will receive no compensation and waive all claims for compensation from the U.S. government in exchange for my participation in this research.”
 

--- a/pages/stakeholder-and-user-interviews.md
+++ b/pages/stakeholder-and-user-interviews.md
@@ -14,7 +14,7 @@ To build consensus about the problem statement and research objectives.
 
 ## Time required
 
-**Small:** 1–2 hours per interviewee
+**Medium:** 1–2 hours per interviewee
 
 ## How to do it
 


### PR DESCRIPTION
### Changes
- Card Sorting: Made two sub-categories h3 instead of h2
- Cognitive walkthrough: Made Additional resources h2, missing ##
- Design studio: changed hyphens to en-dashes
- Heuristic analysis: Added “To” to beginning of Reasons to match
format of others
- Mental modeling, Metrics definition, Design studio: Made “I” in
“Implications” lowercase
- Stakeholder and user interviews: changed time required to Medium to match how we were including prep time in these recommendations
- Recruiting: Trying to correct markdown format, adding space between
bulleted list so that bullets render

### Review
@jameshupp 

### Notes
- Thank you James for this excellent commit format that I'm copying now.
- Probably want to check that the formatting fixes for Recruiting and Cognitive walkthrough actually worked. I'm not a markdown pro yet
- These changes have already been made in the print template.